### PR TITLE
fix: display otherplayer placeholder returning raw value not display value

### DIFF
--- a/src/main/java/svar/ajneb97/api/ServerVariablesExpansion.java
+++ b/src/main/java/svar/ajneb97/api/ServerVariablesExpansion.java
@@ -133,7 +133,7 @@ public class ServerVariablesExpansion extends PlaceholderExpansion {
             int index = var.indexOf(":");
             String playerName = var.substring(0,index);
             String variable = var.substring(index+1);
-            return ServerVariablesAPI.getVariableValue(playerName,variable).getResultValue();
+            return ServerVariablesAPI.getVariableDisplay(playerName,variable);
         }else if(identifier.startsWith("value_")){
             // %servervariables_value_<variable>%
             if(player == null){


### PR DESCRIPTION
When trying to use the `%servervariables_display_otherplayer_<player>:<variable>%` placeholder, I've noticed it gives the raw value of the variable rather than formatting the variable according to the display option in config.

This Pull Request aims to fix said issue. :)